### PR TITLE
2.0.2.0 change column display and optimise

### DIFF
--- a/CWLSLastSeenTool/CWLSLastSeenTool.csproj
+++ b/CWLSLastSeenTool/CWLSLastSeenTool.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
   <PropertyGroup>
-    <Version>2.0.1.0</Version>
+    <Version>2.0.2.0</Version>
     <Description>Tools to make managing Linkshells and Cross-world Linkshells easier.</Description>
     <PackageProjectUrl>https://github.com/radax864/CWLSLastSeenTool</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/CWLSLastSeenTool/Plugin.cs
+++ b/CWLSLastSeenTool/Plugin.cs
@@ -22,6 +22,18 @@ public sealed class Plugin : IDalamudPlugin
     private ConfigWindow ConfigWindow { get; init; }
     private MainWindow MainWindow { get; init; }
 
+    //new variables to store table data
+    public string[] listNamesCWLS = [""];
+    public string[] listDatesCWLS = [""];
+    public string[] tableDataCWLS = [""];
+    public int dataReadyCWLS = 0;
+    public bool sortSpecsDirtyCWLS = false;
+    public string[] listNamesLS = [""];
+    public string[] listDatesLS = [""];
+    public string[] tableDataLS = [""];
+    public int dataReadyLS = 0;
+    public bool sortSpecsDirtyLS = false;
+
     public Plugin()
     {
         Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();

--- a/CWLSLastSeenTool/Utils/ShellTools.cs
+++ b/CWLSLastSeenTool/Utils/ShellTools.cs
@@ -10,16 +10,72 @@ namespace CWLSLastSeenTool.Utils;
 
 public class ShellTools : IDisposable
 {
+    private Plugin Plugin;
     private Configuration Configuration;
 
     public ShellTools(Plugin plugin)
     {
+        Plugin = plugin;
         Configuration = plugin.Configuration;
     }
 
     public void Dispose()
     {
         //nothing to dispose currently
+    }
+
+    public void RefreshDisplayData(string shellType)
+    {
+        if (string.Equals(shellType, "CWLS") && Configuration.CWLSCSVDataVersion == Configuration.CSVDataVersion && !Configuration.CWLSCSVList.Equals("") && !Configuration.CWLSCSVListDate.Equals("") && !Configuration.CWLSCSVData.Equals(""))
+        {
+            //make list of cwls names for drop down
+            Plugin.listNamesCWLS = Configuration.CWLSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            //make list of cache dates to display next to cwls list drop down
+            Plugin.listDatesCWLS = Configuration.CWLSCSVListDate.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            //make data rows for display table
+            Plugin.tableDataCWLS = Configuration.CWLSCSVData.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+
+            //set data ready to 1, ready to display
+            Plugin.dataReadyCWLS = 1;
+            Plugin.sortSpecsDirtyCWLS = true;
+        }
+        else if (string.Equals(shellType, "CWLS") && Configuration.CWLSCSVDataVersion == 0 && !Configuration.CWLSCSVList.Equals("") && !Configuration.CWLSCSVListDate.Equals("") && !Configuration.CWLSCSVData.Equals(""))
+        {
+            //set data ready to 2, update data
+            Plugin.dataReadyCWLS = 2;
+        }
+        else if (string.Equals(shellType, "CWLS"))
+        {
+            //if all shells have been removed
+            Plugin.dataReadyCWLS = 0;
+        }
+        else if (string.Equals(shellType, "LS") && Configuration.LSCSVDataVersion == Configuration.CSVDataVersion && !Configuration.LSCSVList.Equals("") && !Configuration.LSCSVListDate.Equals("") && !Configuration.LSCSVData.Equals(""))
+        {
+            //make list of cwls names for drop down
+            Plugin.listNamesLS = Configuration.LSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            //make list of cache dates to display next to cwls list drop down
+            Plugin.listDatesLS = Configuration.LSCSVListDate.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            //make data rows for display table
+            Plugin.tableDataLS = Configuration.LSCSVData.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+
+            //set data ready to 1, ready to display
+            Plugin.dataReadyLS = 1;
+            Plugin.sortSpecsDirtyLS = true;
+        }
+        else if (string.Equals(shellType, "LS") && Configuration.LSCSVDataVersion == 0 && !Configuration.LSCSVList.Equals("") && !Configuration.LSCSVListDate.Equals("") && !Configuration.LSCSVData.Equals(""))
+        {
+            //set data ready to 2, update data
+            Plugin.dataReadyLS = 2;
+        }
+        else if (string.Equals(shellType, "LS"))
+        {
+            //if all shells have been removed
+            Plugin.dataReadyLS = 0;
+        }
     }
 
     private string WorldIdToName(ushort worldId)
@@ -67,7 +123,7 @@ public class ShellTools : IDisposable
         }
     }
 
-    public void CacheShell(string shellType, string cacheType = "Normal") //shellType CWLS and LS, cacheType Normal and Merge
+    public void CacheShell(string shellType, string cacheType = "Normal", int mergeIndex = 0) //shellType CWLS and LS, cacheType Normal and Merge
     {
         //initial sanity check
         Configuration.DEBUGString = "";
@@ -89,12 +145,12 @@ public class ShellTools : IDisposable
         if (string.Equals(cacheType, "Merge") && string.Equals(shellType, "CWLS") && !Configuration.CWLSCSVList.Equals(""))
         {
             string[] mergeList = Configuration.CWLSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            mergeListName = mergeList[Configuration.CWLSListIndex];
+            mergeListName = mergeList[mergeIndex];
         }
         else if (string.Equals(cacheType, "Merge") && string.Equals(shellType, "LS") && !Configuration.LSCSVList.Equals(""))
         {
             string[] mergeList = Configuration.LSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            mergeListName = mergeList[Configuration.LSListIndex];
+            mergeListName = mergeList[mergeIndex];
         }
         else if (string.Equals(cacheType, "Merge"))
         {
@@ -313,6 +369,7 @@ public class ShellTools : IDisposable
             Configuration.DEBUGString = "Cross-world Linkshell info written successfully.";
             Configuration.Save();
             ClampShellListIndex("CWLS");
+            RefreshDisplayData("CWLS");
         }
         else if (string.Equals(shellType, "LS"))
         {
@@ -323,6 +380,7 @@ public class ShellTools : IDisposable
             Configuration.DEBUGString = "Linkshell info written successfully.";
             Configuration.Save();
             ClampShellListIndex("LS");
+            RefreshDisplayData("LS");
         }
         else
         {
@@ -430,6 +488,7 @@ public class ShellTools : IDisposable
             Configuration.DEBUGString = "Cross-world Linkshell info removed successfully.";
             Configuration.Save();
             ClampShellListIndex("CWLS");
+            RefreshDisplayData("CWLS");
         }
         else if (string.Equals(shellType, "LS"))
         {
@@ -440,6 +499,7 @@ public class ShellTools : IDisposable
             Configuration.DEBUGString = "Linkshell info removed successfully.";
             Configuration.Save();
             ClampShellListIndex("LS");
+            RefreshDisplayData("LS");
         }
         else
         {
@@ -511,6 +571,7 @@ public class ShellTools : IDisposable
         Configuration.CWLSCSVListDate = sb4.ToString().Remove(sb4.ToString().Length - 2);
         Configuration.Save();
         ClampShellListIndex("CWLS");
+        RefreshDisplayData("CWLS");
     }
 
     public void TEMPUpdateLSData() //temp method to update data from csv version 0 to 1
@@ -571,6 +632,7 @@ public class ShellTools : IDisposable
         Configuration.LSCSVListDate = sb4.ToString().Remove(sb4.ToString().Length - 2);
         Configuration.Save();
         ClampShellListIndex("LS");
+        RefreshDisplayData("LS");
     }
 
 }

--- a/CWLSLastSeenTool/Windows/ConfigWindow.cs
+++ b/CWLSLastSeenTool/Windows/ConfigWindow.cs
@@ -9,8 +9,11 @@ namespace CWLSLastSeenTool.Windows;
 
 public class ConfigWindow : Window, IDisposable
 {
+    private Plugin Plugin;
     private Configuration Configuration;
     private ShellTools ShellTools;
+    private int listIndexCWLS = 0;
+    private int listIndexLS = 0;
 
     public ConfigWindow(Plugin plugin) : base("Linkshell Tools Advanced Options")
     {
@@ -24,6 +27,7 @@ public class ConfigWindow : Window, IDisposable
             MaximumSize = new Vector2(480, float.MaxValue)
         };
 
+        Plugin = plugin;
         Configuration = plugin.Configuration;
         ShellTools = new ShellTools(plugin);
     }
@@ -46,28 +50,55 @@ public class ConfigWindow : Window, IDisposable
         ImGui.Separator();
         ImGui.Spacing();
 
-        string activeCWLSList = "No CWLS Have Been Cached";
-        if (!Configuration.CWLSCSVList.Equals(""))
+        if (Plugin.dataReadyCWLS == 1)
         {
-            string[] CWLSList;
-            CWLSList = Configuration.CWLSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            activeCWLSList = CWLSList[Configuration.CWLSListIndex];
-        }
-        ImGui.Text($"Selected CWLS List: {activeCWLSList}");
-        ImGui.Spacing();
+            ImGui.SetNextItemWidth(200.0f);
 
-        if (ImGui.Button("Remove Selected CWLS List") && ImGui.GetIO().KeyCtrl)
-        {
-            ShellTools.RemoveShell("Shell", "CWLS", activeCWLSList);
-        }
-        ImGui.TextWrapped("Removes all entries from the current list.");
-        ImGui.Spacing();
+            using (var cwlspicklist = ImRaii.Combo("##cwls_picklist", Plugin.listNamesCWLS[listIndexCWLS]))
+            {
+                if (cwlspicklist)
+                {
+                    for (int i = 0; i < Plugin.listNamesCWLS.Length; i++)
+                    {
+                        bool isselected = listIndexCWLS == i;
+                        if (ImGui.Selectable(Plugin.listNamesCWLS[i], isselected))
+                        {
+                            listIndexCWLS = i;
+                        }
+                        if (isselected)
+                        {
+                            ImGui.SetItemDefaultFocus();
+                        }
+                    }
+                }
+            }
 
-        if (ImGui.Button("Merge/Update CWLS List") && ImGui.GetIO().KeyCtrl)
-        {
-            ShellTools.CacheShell("CWLS", "Merge");
+            ImGui.SameLine();
+            if (ImGui.Button("Remove List") && ImGui.GetIO().KeyCtrl)
+            {
+                ShellTools.RemoveShell("Shell", "CWLS", Plugin.listNamesCWLS[listIndexCWLS]);
+                listIndexCWLS = 0;
+            }
+            ImGui.SameLine();
+
+            if (ImGui.Button("Merge/Update List") && ImGui.GetIO().KeyCtrl)
+            {
+                ShellTools.CacheShell("CWLS", "Merge", listIndexCWLS);
+                listIndexCWLS = 0;
+            }
+            
+            ImGui.Spacing();
+            ImGui.TextWrapped("Remove List: Removes all entries from the selected list.");
+            ImGui.Spacing();
+            ImGui.TextWrapped("Merge/Update List: Updates the name of the selected CWLS list and caches its members against the currently opened Cross-world Linkshell. This will fail if the Cross-world Linkshell has already been cached/exists in the CWLS list.");
+            ImGui.Spacing();
         }
-        ImGui.TextWrapped("Updates the name of the active CWLS list and caches its members against the currently selected Cross-world Linkshell. This will fail if the Cross-world Linkshell has already been cached/exists in the CWLS list.");
+        else
+        {
+            ImGui.TextWrapped("No CWLS Have Been Cached");
+            listIndexCWLS = 0;
+            listIndexLS = 0;
+        }
 
         ImGui.Spacing();
         ImGui.Spacing();
@@ -86,6 +117,7 @@ public class ConfigWindow : Window, IDisposable
             Configuration.CWLSCSVList = "";
             Configuration.CWLSCSVListDate = "";
             Configuration.Save();
+            ShellTools.RefreshDisplayData("CWLS");
         }
 
         ImGui.Spacing();
@@ -98,6 +130,7 @@ public class ConfigWindow : Window, IDisposable
             Configuration.CWLSCSVListDate = Configuration.CWLSCSVListDateBACKUP;
             Configuration.Save();
             ShellTools.ClampShellListIndex("CWLS");
+            ShellTools.RefreshDisplayData("CWLS");
         }
 
         ImGui.Spacing();
@@ -141,28 +174,55 @@ public class ConfigWindow : Window, IDisposable
         ImGui.Separator();
         ImGui.Spacing();
 
-        string activeLSList = "No Linkshells Have Been Cached";
-        if (!Configuration.LSCSVList.Equals(""))
+        if (Plugin.dataReadyLS == 1)
         {
-            string[] LSList;
-            LSList = Configuration.LSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            activeLSList = LSList[Configuration.LSListIndex];
-        }
-        ImGui.Text($"Selected Linkshell List: {activeLSList}");
-        ImGui.Spacing();
+            ImGui.SetNextItemWidth(200.0f);
 
-        if (ImGui.Button("Remove Selected Linkshell List") && ImGui.GetIO().KeyCtrl)
-        {
-            ShellTools.RemoveShell("Shell", "LS", activeLSList);
-        }
-        ImGui.TextWrapped("Removes all entries from the current list.");
-        ImGui.Spacing();
+            using (var lspicklist = ImRaii.Combo("##ls_picklist", Plugin.listNamesLS[listIndexLS]))
+            {
+                if (lspicklist)
+                {
+                    for (int i = 0; i < Plugin.listNamesLS.Length; i++)
+                    {
+                        bool isselected = listIndexLS == i;
+                        if (ImGui.Selectable(Plugin.listNamesLS[i], isselected))
+                        {
+                            listIndexLS = i;
+                        }
+                        if (isselected)
+                        {
+                            ImGui.SetItemDefaultFocus();
+                        }
+                    }
+                }
+            }
 
-        if (ImGui.Button("Merge/Update Linkshell List") && ImGui.GetIO().KeyCtrl)
-        {
-            ShellTools.CacheShell("LS", "Merge");
+            ImGui.SameLine();
+            if (ImGui.Button("Remove List") && ImGui.GetIO().KeyCtrl)
+            {
+                ShellTools.RemoveShell("Shell", "LS", Plugin.listNamesLS[listIndexLS]);
+                listIndexLS = 0;
+            }
+            ImGui.SameLine();
+
+            if (ImGui.Button("Merge/Update List") && ImGui.GetIO().KeyCtrl)
+            {
+                ShellTools.CacheShell("LS", "Merge", listIndexLS);
+                listIndexLS = 0;
+            }
+            
+            ImGui.Spacing();
+            ImGui.TextWrapped("Remove List: Removes all entries from the selected list.");
+            ImGui.Spacing();
+            ImGui.TextWrapped("Merge/Update List: Updates the name of the selected list and caches its members against the currently opened Linkshell. This will fail if the Linkshell has already been cached/exists in the Linkshell list.");
+            ImGui.Spacing();
         }
-        ImGui.TextWrapped("Updates the name of the active Linkshell list and caches its members against the currently selected Linkshell. This will fail if the Linkshell has already been cached/exists in the Linkshell list.");
+        else
+        {
+            ImGui.TextWrapped("No Linkshells Have Been Cached");
+            listIndexCWLS = 0;
+            listIndexLS = 0;
+        }
 
         ImGui.Spacing();
         ImGui.Spacing();
@@ -181,6 +241,7 @@ public class ConfigWindow : Window, IDisposable
             Configuration.LSCSVList = "";
             Configuration.LSCSVListDate = "";
             Configuration.Save();
+            ShellTools.RefreshDisplayData("LS");
         }
 
         ImGui.Spacing();
@@ -193,6 +254,7 @@ public class ConfigWindow : Window, IDisposable
             Configuration.LSCSVListDate = Configuration.LSCSVListDateBACKUP;
             Configuration.Save();
             ShellTools.ClampShellListIndex("LS");
+            ShellTools.RefreshDisplayData("LS");
         }
 
         ImGui.Spacing();
@@ -272,6 +334,12 @@ public class ConfigWindow : Window, IDisposable
            Configuration.DEBUGInt3 = 0;
            Configuration.Save();
         }
+    }
+
+    public override void OnOpen()
+    {
+        listIndexCWLS = 0;
+        listIndexLS = 0;
     }
 
     public override void Draw()

--- a/CWLSLastSeenTool/Windows/MainWindow.cs
+++ b/CWLSLastSeenTool/Windows/MainWindow.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using Dalamud.Bindings.ImGui;
 using CWLSLastSeenTool.Utils;
+using Dalamud.Interface;
 
 namespace CWLSLastSeenTool.Windows;
 
@@ -14,6 +15,11 @@ public class MainWindow : Window, IDisposable
     private ShellTools ShellTools;
     private int memberCount = 0;
     private int onlineCount = 0;
+
+    //font colours
+    private Vector4 vectRed = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
+    private Vector4 vectGreen = new Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    private Vector4 vectGray = new Vector4(0.501f, 0.501f, 0.501f, 1.0f);
 
     public MainWindow(Plugin plugin)
         : base("Linkshell Tools") //, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
@@ -40,27 +46,19 @@ public class MainWindow : Window, IDisposable
     {
         ImGui.Spacing();
 
-        //check for empty strings that will cause things to break
-        if (Configuration.CWLSCSVDataVersion == Configuration.CSVDataVersion && !Configuration.CWLSCSVList.Equals("") && !Configuration.CWLSCSVListDate.Equals("") && !Configuration.CWLSCSVData.Equals(""))
+        //check for empty strings that will cause things to break moved to RefreshDisplayData method
+        if (Plugin.dataReadyCWLS == 1)
         {
-            //make list of cwls names for drop down
-            string[] CWLSList;
-            CWLSList = Configuration.CWLSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-
-            //make list of cache dates to display next to cwls list drop down
-            string[] CWLSListDate;
-            CWLSListDate = Configuration.CWLSCSVListDate.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-
             ImGui.SetNextItemWidth(300.0f);
 
-            using (var cwlspicklist = ImRaii.Combo("##cwls_picklist", CWLSList[Configuration.CWLSListIndex]))
+            using (var cwlspicklist = ImRaii.Combo("##cwls_picklist", Plugin.listNamesCWLS[Configuration.CWLSListIndex]))
             {
                 if (cwlspicklist)
                 {
-                    for (int i = 0; i < CWLSList.Length; i++)
+                    for (int i = 0; i < Plugin.listNamesCWLS.Length; i++)
                     {
                         bool isselected = Configuration.CWLSListIndex == i;
-                        if (ImGui.Selectable(CWLSList[i], isselected))
+                        if (ImGui.Selectable(Plugin.listNamesCWLS[i], isselected))
                         {
                             Configuration.CWLSListIndex = i;
                             Configuration.Save();
@@ -85,17 +83,9 @@ public class MainWindow : Window, IDisposable
             ImGui.Spacing();
 
             ImGui.SameLine();
-            ImGui.Text($"Last Cached: {CWLSListDate[Configuration.CWLSListIndex]}");
+            ImGui.Text($"Last Cached: {Plugin.listDatesCWLS[Configuration.CWLSListIndex]}");
 
             ImGui.Spacing();
-
-            //start making the display table
-            string[] Lines;
-            Lines = Configuration.CWLSCSVData.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-            string[] Fields;
-
-            Vector4 vectRed = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
-            Vector4 vectGreen = new Vector4(0.0f, 1.0f, 0.0f, 1.0f);
 
             ImGuiTableFlags flags = ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Sortable;
 
@@ -113,59 +103,64 @@ public class MainWindow : Window, IDisposable
 
                     ImGuiTableSortSpecsPtr sortSpecs = ImGui.TableGetSortSpecs();
 
-                    Array.Sort(Lines, (line1, line2) =>
+                    if (sortSpecs.SpecsDirty || Plugin.sortSpecsDirtyCWLS)
                     {
-                        // Don't sort Lines[0] - it's the table headers
-                        if (line1 == Lines[0]) return -1;
-                        if (line2 == Lines[0]) return 1;
-
-                        string[] fields1 = line1.Split(new char[] { '\t' });
-                        string[] fields2 = line2.Split(new char[] { '\t' });
-
-                        short index = sortSpecs.Specs.ColumnIndex; // this is the column that we're sorting by
-                        int comparison = 0;
-
-                        switch (index)
+                        Array.Sort(Plugin.tableDataCWLS, (line1, line2) =>
                         {
-                            case 0: // Names
-                                comparison = string.Compare(fields1[0], fields2[0]);
-                                break;
-                            case 1: // Online/Offline
-                                comparison = string.Compare(fields1[2], fields2[2]);
-                                break;
-                            case 2: // Last Seen Date
-                                var time1 = DateTime.Parse(fields1[3]);
-                                var time2 = DateTime.Parse(fields2[3]);
-                                comparison = time1.CompareTo(time2);
-                                break;
-                            case 3: // days since seen
-                                comparison = int.Parse(fields1[4]) - int.Parse(fields2[4]);
-                                break;
-                        }
+                            // Don't sort Lines[0] - it's the table headers
+                            if (line1 == Plugin.tableDataCWLS[0]) return -1;
+                            if (line2 == Plugin.tableDataCWLS[0]) return 1;
 
-                        if (comparison == 0 && index != 0)
-                        {
-                            // If the lines have the same value in this column, sort by name as a second layer.
-                            // Always sort ascending for the secondary name sort
-                            return string.Compare(fields1[0], fields2[0]);
-                        }
+                            string[] fields1 = line1.Split(new char[] { '\t' });
+                            string[] fields2 = line2.Split(new char[] { '\t' });
 
-                        if (comparison != 0)
-                        {
-                            // Check sort direction here and return the inverse if descending
-                            return sortSpecs.Specs.SortDirection == ImGuiSortDirection.Descending ? -comparison : comparison;
-                        }
-                        return 0;
-                    });
+                            short index = sortSpecs.Specs.ColumnIndex; // this is the column that we're sorting by
+                            int comparison = 0;
+
+                            switch (index)
+                            {
+                                case 0: // Names
+                                    comparison = string.Compare(fields1[0], fields2[0]);
+                                    break;
+                                case 1: // Online/Offline
+                                    comparison = string.Compare(fields1[2], fields2[2]);
+                                    break;
+                                case 2: // Last Seen Date
+                                    var time1 = DateTime.Parse(fields1[3]);
+                                    var time2 = DateTime.Parse(fields2[3]);
+                                    comparison = time1.CompareTo(time2);
+                                    break;
+                                case 3: // days since seen
+                                    comparison = int.Parse(fields1[4]) - int.Parse(fields2[4]);
+                                    break;
+                            }
+
+                            if (comparison == 0 && index != 0)
+                            {
+                                // If the lines have the same value in this column, sort by name as a second layer.
+                                // Always sort ascending for the secondary name sort
+                                return string.Compare(fields1[0], fields2[0]);
+                            }
+
+                            if (comparison != 0)
+                            {
+                                // Check sort direction here and return the inverse if descending
+                                return sortSpecs.Specs.SortDirection == ImGuiSortDirection.Descending ? -comparison : comparison;
+                            }
+                            return 0;
+                        });
+                        sortSpecs.SpecsDirty = false;
+                        Plugin.sortSpecsDirtyCWLS = false;
+                    }
 
                     memberCount = 0;
                     onlineCount = 0;
 
-                    for (int i = 1; i < Lines.GetLength(0); i++)
+                    for (int i = 1; i < Plugin.tableDataCWLS.GetLength(0); i++)
                     {
-                        Fields = Lines[i].Split(new char[] { '\t' }); //0 = member, 1 = homeworld, 2 = state, 3 = lastseen, 4 = seendays, 5 = listname, 6 = cachedate, 7 = ispresent
+                        string[] Fields = Plugin.tableDataCWLS[i].Split(new char[] { '\t' }); //0 = member, 1 = homeworld, 2 = state, 3 = lastseen, 4 = seendays, 5 = listname, 6 = cachedate, 7 = ispresent
 
-                        if (Fields[5].Equals(CWLSList[Configuration.CWLSListIndex]))
+                        if (Fields[5].Equals(Plugin.listNamesCWLS[Configuration.CWLSListIndex]))
                         {
                             ImGui.TableNextRow();
                             ImGui.TableNextColumn();
@@ -189,11 +184,18 @@ public class MainWindow : Window, IDisposable
                                 ImGui.TextColored(vectRed, $"{Fields[2]}");
                             }
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{Fields[3].Substring(0, 10)}"); //lastseen
+                            if (int.Parse(Fields[4]) == 40000) //lastseen
+                            {
+                                ImGui.TextColored(vectGray, "Never Seen");
+                            }
+                            else
+                            {
+                                ImGui.Text($"{Fields[3].Substring(0, 10)}");
+                            }
                             ImGui.TableNextColumn();
                             if (int.Parse(Fields[4]) == 40000) //seendays
                             {
-                                ImGui.Text("Never Seen");
+                                ImGui.TextColored(vectGray, $"Cached {Fields[3].Substring(0, 10)}");
                             }
                             else
                             {
@@ -209,7 +211,7 @@ public class MainWindow : Window, IDisposable
                 }
             }
         }
-        else if (Configuration.CWLSCSVDataVersion == 0 && !Configuration.CWLSCSVList.Equals("") && !Configuration.CWLSCSVListDate.Equals("") && !Configuration.CWLSCSVData.Equals(""))
+        else if (Plugin.dataReadyCWLS == 2)
         {
             ImGui.Spacing();
 
@@ -240,25 +242,19 @@ public class MainWindow : Window, IDisposable
     {
         ImGui.Spacing();
 
-        //check for empty strings that will cause things to break
-        if (Configuration.LSCSVDataVersion == Configuration.CSVDataVersion && !Configuration.LSCSVList.Equals("") && !Configuration.LSCSVListDate.Equals("") && !Configuration.LSCSVData.Equals(""))
+        //check for empty strings that will cause things to break moved to RefreshDisplayData method
+        if (Plugin.dataReadyLS == 1)
         {
-            //make list of ls names for drop down
-            string[] LSList = Configuration.LSCSVList.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-
-            //make list of cache dates to display next to cwls list drop down
-            string[] LSListDate = Configuration.LSCSVListDate.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
-
             ImGui.SetNextItemWidth(300.0f);
 
-            using (var lspicklist = ImRaii.Combo("##ls_picklist", LSList[Configuration.LSListIndex]))
+            using (var lspicklist = ImRaii.Combo("##ls_picklist", Plugin.listNamesLS[Configuration.LSListIndex]))
             {
                 if (lspicklist)
                 {
-                    for (int i = 0; i < LSList.Length; i++)
+                    for (int i = 0; i < Plugin.listNamesLS.Length; i++)
                     {
                         bool isselected = Configuration.LSListIndex == i;
-                        if (ImGui.Selectable(LSList[i], isselected))
+                        if (ImGui.Selectable(Plugin.listNamesLS[i], isselected))
                         {
                             Configuration.LSListIndex = i;
                             Configuration.Save();
@@ -283,17 +279,9 @@ public class MainWindow : Window, IDisposable
             ImGui.Spacing();
 
             ImGui.SameLine();
-            ImGui.Text($"Last Cached: {LSListDate[Configuration.LSListIndex]}");
+            ImGui.Text($"Last Cached: {Plugin.listDatesLS[Configuration.LSListIndex]}");
 
             ImGui.Spacing();
-
-            //start making the display table
-            string[] Lines;
-            Lines = Configuration.LSCSVData.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-            string[] Fields;
-
-            Vector4 vectRed = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
-            Vector4 vectGreen = new Vector4(0.0f, 1.0f, 0.0f, 1.0f);
 
             ImGuiTableFlags flags = ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Sortable;
 
@@ -311,59 +299,65 @@ public class MainWindow : Window, IDisposable
 
                     ImGuiTableSortSpecsPtr sortSpecs = ImGui.TableGetSortSpecs();
 
-                    Array.Sort(Lines, (line1, line2) =>
+                    if (sortSpecs.SpecsDirty || Plugin.sortSpecsDirtyLS)
                     {
-                        // Don't sort Lines[0] - it's the table headers
-                        if (line1 == Lines[0]) return -1;
-                        if (line2 == Lines[0]) return 1;
-
-                        string[] fields1 = line1.Split(new char[] { '\t' });
-                        string[] fields2 = line2.Split(new char[] { '\t' });
-
-                        short index = sortSpecs.Specs.ColumnIndex; // this is the column that we're sorting by
-                        int comparison = 0;
-
-                        switch (index)
+                        Array.Sort(Plugin.tableDataLS, (line1, line2) =>
                         {
-                            case 0: // Names
-                                comparison = string.Compare(fields1[0], fields2[0]);
-                                break;
-                            case 1: // Online/Offline
-                                comparison = string.Compare(fields1[2], fields2[2]);
-                                break;
-                            case 2: // Last Seen Date
-                                var time1 = DateTime.Parse(fields1[3]);
-                                var time2 = DateTime.Parse(fields2[3]);
-                                comparison = time1.CompareTo(time2);
-                                break;
-                            case 3: // days since seen
-                                comparison = int.Parse(fields1[4]) - int.Parse(fields2[4]);
-                                break;
-                        }
+                            // Don't sort Lines[0] - it's the table headers
+                            if (line1 == Plugin.tableDataLS[0]) return -1;
+                            if (line2 == Plugin.tableDataLS[0]) return 1;
 
-                        if (comparison == 0 && index != 0)
-                        {
-                            // If the lines have the same value in this column, sort by name as a second layer.
-                            // Always sort ascending for the secondary name sort
-                            return string.Compare(fields1[0], fields2[0]);
-                        }
+                            string[] fields1 = line1.Split(new char[] { '\t' });
+                            string[] fields2 = line2.Split(new char[] { '\t' });
 
-                        if (comparison != 0)
-                        {
-                            // Check sort direction here and return the inverse if descending
-                            return sortSpecs.Specs.SortDirection == ImGuiSortDirection.Descending ? -comparison : comparison;
-                        }
-                        return 0;
-                    });
+                            short index = sortSpecs.Specs.ColumnIndex; // this is the column that we're sorting by
+                            int comparison = 0;
+
+                            switch (index)
+                            {
+                                case 0: // Names
+                                    comparison = string.Compare(fields1[0], fields2[0]);
+                                    break;
+                                case 1: // Online/Offline
+                                    comparison = string.Compare(fields1[2], fields2[2]);
+                                    break;
+                                case 2: // Last Seen Date
+                                    var time1 = DateTime.Parse(fields1[3]);
+                                    var time2 = DateTime.Parse(fields2[3]);
+                                    comparison = time1.CompareTo(time2);
+                                    break;
+                                case 3: // days since seen
+                                    comparison = int.Parse(fields1[4]) - int.Parse(fields2[4]);
+                                    break;
+                            }
+
+                            if (comparison == 0 && index != 0)
+                            {
+                                // If the lines have the same value in this column, sort by name as a second layer.
+                                // Always sort ascending for the secondary name sort
+                                return string.Compare(fields1[0], fields2[0]);
+                            }
+
+                            if (comparison != 0)
+                            {
+                                // Check sort direction here and return the inverse if descending
+                                return sortSpecs.Specs.SortDirection == ImGuiSortDirection.Descending ? -comparison : comparison;
+                            }
+                            return 0;
+                        });
+                        sortSpecs.SpecsDirty = false;
+                        Plugin.sortSpecsDirtyLS = false;
+
+                    }
 
                     memberCount = 0;
                     onlineCount = 0;
 
-                    for (int i = 1; i < Lines.GetLength(0); i++)
+                    for (int i = 1; i < Plugin.tableDataLS.GetLength(0); i++)
                     {
-                        Fields = Lines[i].Split(new char[] { '\t' }); //0 = member, 1 = homeworld, 2 = state, 3 = lastseen, 4 = seendays, 5 = listname, 6 = cachedate, 7 = ispresent
+                        string[] Fields = Plugin.tableDataLS[i].Split(new char[] { '\t' }); //0 = member, 1 = homeworld, 2 = state, 3 = lastseen, 4 = seendays, 5 = listname, 6 = cachedate, 7 = ispresent
 
-                        if (Fields[5].Equals(LSList[Configuration.LSListIndex]))
+                        if (Fields[5].Equals(Plugin.listNamesLS[Configuration.LSListIndex]))
                         {
                             ImGui.TableNextRow();
                             ImGui.TableNextColumn();
@@ -387,11 +381,18 @@ public class MainWindow : Window, IDisposable
                                 ImGui.TextColored(vectRed, $"{Fields[2]}");
                             }
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{Fields[3].Substring(0, 10)}"); //lastseen
+                            if (int.Parse(Fields[4]) == 40000) //lastseen
+                            {
+                                ImGui.TextColored(vectGray, "Never Seen");
+                            }
+                            else
+                            {
+                                ImGui.Text($"{Fields[3].Substring(0, 10)}");
+                            }
                             ImGui.TableNextColumn();
                             if (int.Parse(Fields[4]) == 40000) //seendays
                             {
-                                ImGui.Text("Never Seen");
+                                ImGui.TextColored(vectGray, $"Cached {Fields[3].Substring(0, 10)}");
                             }
                             else
                             {
@@ -407,7 +408,7 @@ public class MainWindow : Window, IDisposable
                 }
             }
         }
-        else if (Configuration.LSCSVDataVersion == 0 && !Configuration.LSCSVList.Equals("") && !Configuration.LSCSVListDate.Equals("") && !Configuration.LSCSVData.Equals(""))
+        else if (Plugin.dataReadyLS == 2)
         {
             ImGui.Spacing();
 
@@ -427,17 +428,18 @@ public class MainWindow : Window, IDisposable
 
             ImGui.TextWrapped("No Linkshell Data. Please open up a Linkshell and click the Cache Linkshell Members button in this window.");
 
-            if (Plugin.PlayerState.CurrentWorld.Value.DataCenter.Value.Name.ToString() != null)
-            {
-                ImGui.Text($"{Plugin.PlayerState.CurrentWorld.Value.DataCenter.Value.Name.ToString()}");
-            }
-
             if (ImGui.Button("Cache Members"))
             {
                 ShellTools.CacheShell("LS");
             }
 
         }
+    }
+
+    public override void OnOpen()
+    {
+        ShellTools.RefreshDisplayData("CWLS");
+        ShellTools.RefreshDisplayData("LS");
     }
 
     public override void Draw()


### PR DESCRIPTION
2.0.2.0
- Linkshell and Cross-world Linkshell members that have been cached but have not yet been seen online will now display Never Seen under the Last Seen column and the date they were cached under the Days Since column. Sorting functions the same as before and stored data has not been changed.
- Remove List and Merge/Update List options under Advanced Options now use their own pick lists for better user experience.
- General optimisation. Data for display tables is now only regenerated/read from plugin configuration storage and sorted when required instead of every frame.